### PR TITLE
fix emmet bug not inserting the correct template

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/SvelteFileViewProvider.kt
+++ b/src/main/java/dev/blachut/svelte/lang/SvelteFileViewProvider.kt
@@ -17,6 +17,9 @@ class SvelteFileViewProvider internal constructor(psiManager: PsiManager, virtua
     private val htmlLanguage = HTMLLanguage.INSTANCE
 
     override fun getBaseLanguage(): Language {
+        if (virtualFile.extension?.toLowerCase() == "html") {
+            return HTMLLanguage.INSTANCE
+        }
         return SvelteLanguage.INSTANCE
     }
 
@@ -33,6 +36,9 @@ class SvelteFileViewProvider internal constructor(psiManager: PsiManager, virtua
     }
 
     override fun createFile(lang: Language): PsiFile? {
+        if (virtualFile.extension?.toLowerCase() == "html") {
+            return LanguageParserDefinitions.INSTANCE.forLanguage(htmlLanguage).createFile(this)
+        }
         return when {
             lang === htmlLanguage -> {
                 val file = LanguageParserDefinitions.INSTANCE.forLanguage(lang).createFile(this) as PsiFileImpl

--- a/src/main/java/dev/blachut/svelte/lang/SvelteFileViewProviderFactory.kt
+++ b/src/main/java/dev/blachut/svelte/lang/SvelteFileViewProviderFactory.kt
@@ -1,14 +1,24 @@
 package dev.blachut.svelte.lang
 
 import com.intellij.lang.Language
+import com.intellij.lang.html.HTMLLanguage
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.FileViewProviderFactory
+import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiManager
+import com.intellij.testFramework.LightVirtualFile
 
 
 class SvelteFileViewProviderFactory : FileViewProviderFactory {
     override fun createFileViewProvider(virtualFile: VirtualFile, language: Language, psiManager: PsiManager, physical: Boolean): FileViewProvider {
+        if (virtualFile is LightVirtualFile && virtualFile.extension?.toLowerCase() == "html" && language is SvelteLanguage) {
+            // fixes emmet bug #19
+            val file = PsiFileFactory.getInstance(psiManager.project)
+                    .createFileFromText(virtualFile.name, HTMLLanguage.INSTANCE, virtualFile.content, true, true)
+            val vFile = file.virtualFile
+            return SvelteFileViewProvider(psiManager, vFile, physical)
+        }
         return SvelteFileViewProvider(psiManager, virtualFile, physical)
     }
 }

--- a/src/main/java/dev/blachut/svelte/lang/SvelteLanguage.java
+++ b/src/main/java/dev/blachut/svelte/lang/SvelteLanguage.java
@@ -1,7 +1,9 @@
 package dev.blachut.svelte.lang;
 
 import com.intellij.lang.Language;
+import com.intellij.lang.html.HTMLLanguage;
 import com.intellij.psi.templateLanguages.TemplateLanguage;
+import org.jetbrains.annotations.Nullable;
 
 // Kotlin class trips up plugin.xml inspections
 public class SvelteLanguage extends Language implements TemplateLanguage {
@@ -9,5 +11,11 @@ public class SvelteLanguage extends Language implements TemplateLanguage {
 
     private SvelteLanguage() {
         super("Svelte");
+    }
+
+    @Nullable
+    @Override
+    public Language getBaseLanguage() {
+        return HTMLLanguage.INSTANCE;
     }
 }


### PR DESCRIPTION
Somewhat hacky but should fix #19 

Debug info below

> 
> In
> `com.intellij.codeInsight.template.emmet.XmlEmmetParser#getDefaultTemplateKey`
> then
> `com.intellij.codeInsight.template.emmet.ZenCodingUtil#isHtml` ,
> the language is checked and must be HTML or XML and so on
> To pass that condition, you need to override `getBaseLanguage` in `SvelteLanguage` and return `HtmlLanguage.INSTANCE`
> 
> Even so, emmet fails because it creates the wrong dummy file type (SvelteFile instead of HTML File)
> This is because it reads the file language (which is SvelteLanguage) and doesn't look for a base language that is HTML
> So then `com.intellij.codeInsight.template.emmet.tokens.TemplateToken#getXmlTag` fails to find the XML tag that was added dynamically and null is returned
> ![screenshot_16](https://user-images.githubusercontent.com/793712/61241059-a1712780-a73a-11e9-9986-a61e097d5284.png)
> 
> So basically `com.intellij.codeInsight.template.emmet.tokens.TemplateToken#setTemplateText` should use the HTML language instead of the file language which it gets through `callback.getFile().getLanguage()`
> 
> Or we should find a way to allow `PsiTreeUtil` to find an `XmlTag` inside `HTML_FRAGMENT` elements

