### PR TITLE
enable JS injections in attribute values

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/SvelteLanguageInjector.kt
+++ b/src/main/java/dev/blachut/svelte/lang/SvelteLanguageInjector.kt
@@ -1,16 +1,32 @@
 package dev.blachut.svelte.lang
 
 import com.intellij.lang.javascript.JavaScriptSupportLoader
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.InjectedLanguagePlaces
 import com.intellij.psi.LanguageInjector
+import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiLanguageInjectionHost
-import dev.blachut.svelte.lang.psi.SvelteExpression
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.xml.XmlAttributeValue
+import dev.blachut.svelte.lang.psi.SvelteInterpolation
 
 class SvelteLanguageInjector : LanguageInjector {
     override fun getLanguagesToInject(host: PsiLanguageInjectionHost, registrar: InjectedLanguagePlaces) {
-        if (host is SvelteExpression) {
-            registrar.addPlace(JavaScriptSupportLoader.ECMA_SCRIPT_6, TextRange.from(0, host.textLength), null, null)
+        if (host is XmlAttributeValue) {
+            injectJsInAttributeValue(host, registrar)
+        }
+    }
+
+    private fun injectJsInAttributeValue(host: PsiLanguageInjectionHost, registrar: InjectedLanguagePlaces) {
+        val attribute = (host as XmlAttributeValue)
+        val value = attribute.text
+        if (value.contains("{") && value.contains("}")) {
+            val file = PsiFileFactory.getInstance(attribute.project)
+                .createFileFromText("dummy.svelte", SvelteLanguage.INSTANCE, value, true, true)
+            val interpolations = PsiTreeUtil.findChildrenOfType(file, SvelteInterpolation::class.java)
+            for (interpolation in interpolations) {
+                registrar.addPlace(SvelteLanguage.INSTANCE, interpolation.textRange, null, null)
+                registrar.addPlace(JavaScriptSupportLoader.ECMA_SCRIPT_6, interpolation.expression.textRange, null, null)
+            }
         }
     }
 

--- a/src/main/java/dev/blachut/svelte/lang/SvelteLanguageInjector.kt
+++ b/src/main/java/dev/blachut/svelte/lang/SvelteLanguageInjector.kt
@@ -1,0 +1,17 @@
+package dev.blachut.svelte.lang
+
+import com.intellij.lang.javascript.JavaScriptSupportLoader
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.InjectedLanguagePlaces
+import com.intellij.psi.LanguageInjector
+import com.intellij.psi.PsiLanguageInjectionHost
+import dev.blachut.svelte.lang.psi.SvelteExpression
+
+class SvelteLanguageInjector : LanguageInjector {
+    override fun getLanguagesToInject(host: PsiLanguageInjectionHost, registrar: InjectedLanguagePlaces) {
+        if (host is SvelteExpression) {
+            registrar.addPlace(JavaScriptSupportLoader.ECMA_SCRIPT_6, TextRange.from(0, host.textLength), null, null)
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -78,6 +78,7 @@
                          groupKey="html.inspections.group.name"
                          implementationClass="dev.blachut.svelte.lang.inspections.SvelteUnresolvedComponentInspection"/>
         <multiHostInjector implementation="dev.blachut.svelte.lang.SvelteCodeMultiHostInjector"/>
+        <languageInjector implementation="dev.blachut.svelte.lang.SvelteLanguageInjector" />
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
A basic js injection 
![image](https://user-images.githubusercontent.com/793712/61663448-879a8c00-acc8-11e9-8025-30ee75d40b43.png)

It requires more work and is buggy inside a svelte tag like #if and so on

I was debugging the `multiHostInjector` but couldn't find out why it doesn't allow highlighting and code insight (so I gave up)

With this approach, highlighting and code insight works (mostly) fine
I think it's a good path to follow

I can improve it using `referencesSearch` if necessary

