### PR TITLE
Handle component re-exports

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/ComponentImporter.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/ComponentImporter.kt
@@ -1,20 +1,38 @@
 package dev.blachut.svelte.lang.codeInsight
 
+import com.intellij.find.FindManager
+import com.intellij.find.impl.FindManagerImpl
+import com.intellij.lang.ecmascript6.psi.ES6ExportSpecifier
+import com.intellij.lang.ecmascript6.psi.ES6FromClause
 import com.intellij.lang.ecmascript6.psi.impl.ES6CreateImportUtil
 import com.intellij.lang.ecmascript6.psi.impl.ES6ImportPsiUtil
+import com.intellij.lang.ecmascript6.psi.impl.JSImportPathBuilder
+import com.intellij.lang.ecmascript6.psi.impl.JSImportPathConfigurationImpl
 import com.intellij.lang.javascript.formatter.JSCodeStyleSettings
+import com.intellij.lang.javascript.psi.JSElement
 import com.intellij.lang.javascript.psi.JSEmbeddedContent
 import com.intellij.lang.javascript.psi.impl.JSChangeUtil
+import com.intellij.lang.javascript.psi.stubs.ES6ExportedNamesIndex
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiParserFacade
 import com.intellij.psi.XmlElementFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
+import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.xml.XmlTag
+import com.intellij.usageView.UsageInfo
+import com.intellij.util.ArrayUtil
+import com.intellij.util.CommonProcessors
 import com.intellij.xml.util.HtmlUtil
+import dev.blachut.svelte.lang.psi.SvelteFile
+import java.util.*
 
 object ComponentImporter {
     fun insertComponentImport(editor: Editor, currentFile: PsiFile, componentVirtualFile: VirtualFile, componentName: String) {
@@ -59,6 +77,12 @@ object ComponentImporter {
     }
 
     fun getImportText(currentFile: PsiFile, componentVirtualFile: VirtualFile, componentName: String): String {
+        val project = currentFile.project
+
+        // if the component is exported by a module, import it from that module
+        val importText = getFromReExports(project, currentFile, componentVirtualFile, componentName)
+        if (importText != null) return importText
+
         val relativePath = FileUtil.getRelativePath(
             currentFile.virtualFile.parent.path,
             componentVirtualFile.path,
@@ -69,7 +93,42 @@ object ComponentImporter {
         return "import $componentName from \"$prefix$relativePath\"$comma"
     }
 
+    private fun getFromReExports(project: Project, currentFile: PsiFile, componentVirtualFile: VirtualFile, componentName: String): String? {
+        val exports: Collection<JSElement> = StubIndex.getElements(ES6ExportedNamesIndex.KEY, componentName, project, GlobalSearchScope.allScope(project), JSElement::class.java)
+        exports.forEach {
+            if (it is ES6ExportSpecifier) {
+                val declaration = it.declaration ?: return@forEach
+                val from: ES6FromClause = PsiTreeUtil.findChildOfType(declaration, ES6FromClause::class.java)
+                    ?: return@forEach
+                val component = from.resolveReferencedElements().find { referencedFile ->
+                    referencedFile is SvelteFile && referencedFile.viewProvider.virtualFile == componentVirtualFile
+                }
+                component ?: return@forEach
+                val moduleVirtualFile = declaration.containingFile.virtualFile
+                val configuration = JSImportPathConfigurationImpl(currentFile, it, moduleVirtualFile, false)
+                val moduleNameInfo = ES6CreateImportUtil.getExternalFileModuleName(JSImportPathBuilder.createBuilder(configuration))
+                val moduleName = moduleNameInfo.moduleName
+                return "import {$componentName} from \"$moduleName\""
+            }
+        }
+        return null
+    }
+
     private fun findScriptTag(file: PsiFile): XmlTag? {
         return PsiTreeUtil.findChildrenOfType(file, XmlTag::class.java).find { HtmlUtil.isScriptTag(it) }
+    }
+
+    fun findUsages(targetElement: PsiElement, scope: SearchScope?): Collection<UsageInfo> {
+        val project = targetElement.project
+        val handler = (FindManager.getInstance(project) as FindManagerImpl).findUsagesManager.getFindUsagesHandler(targetElement, false)
+
+        val processor = CommonProcessors.CollectProcessor(Collections.synchronizedList(ArrayList<UsageInfo>()))
+        val psiElements = ArrayUtil.mergeArrays(handler!!.primaryElements, handler.secondaryElements)
+        val options = handler.getFindUsagesOptions(null)
+        if (scope != null) options.searchScope = scope
+        for (psiElement in psiElements) {
+            handler.processElementUsages(psiElement, processor, options)
+        }
+        return processor.results
     }
 }

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/ComponentImporter.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/ComponentImporter.kt
@@ -93,7 +93,7 @@ object ComponentImporter {
     fun getImportText(currentFile: PsiFile, componentVirtualFile: VirtualFile, componentName: String, moduleInfo: JSModuleNameInfo? = null): String {
         val comma = JSCodeStyleSettings.getSemicolon(currentFile)
 
-        if (moduleInfo != null) {
+        if (moduleInfo != null && moduleInfo.resolvedFile.extension != "svelte") {
             return "import {$componentName} from \"${moduleInfo.moduleName}\"$comma"
         }
 

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/ComponentLookupObject.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/ComponentLookupObject.kt
@@ -1,5 +1,6 @@
 package dev.blachut.svelte.lang.codeInsight
 
+import com.intellij.lang.javascript.modules.JSModuleNameInfo
 import com.intellij.openapi.vfs.VirtualFile
 
-data class ComponentLookupObject(val file: VirtualFile, val props: List<String?>?)
+data class ComponentLookupObject(val file: VirtualFile, val props: List<String?>?, val moduleInfo: JSModuleNameInfo)

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReferenceSearch.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReferenceSearch.kt
@@ -24,7 +24,7 @@ class SvelteReferenceSearch : QueryExecutor<PsiReference, ReferencesSearch.Searc
     override fun execute(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<in PsiReference>): Boolean {
         ReadAction.run<RuntimeException> {
             val elementToSearch = queryParameters.elementToSearch
-            val containingFile = elementToSearch.containingFile
+            val containingFile = elementToSearch.containingFile ?: return@run
             if (containingFile.virtualFile.fileType is SvelteFileType) {
                 if (elementToSearch is ES6ImportedBinding) {
                     val componentName = (elementToSearch as JSNamedElement).name

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReferenceSearch.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReferenceSearch.kt
@@ -1,13 +1,21 @@
 package dev.blachut.svelte.lang.codeInsight
 
 
+import com.intellij.lang.ecmascript6.psi.ES6ExportSpecifierAlias
+import com.intellij.lang.ecmascript6.psi.ES6ImportExportSpecifierAlias
+import com.intellij.lang.ecmascript6.psi.ES6ImportSpecifierAlias
 import com.intellij.lang.ecmascript6.psi.ES6ImportedBinding
+import com.intellij.lang.javascript.psi.JSNamedElement
 import com.intellij.openapi.application.ReadAction
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceService
 import com.intellij.psi.search.LocalSearchScope
+import com.intellij.psi.search.RequestResultProcessor
 import com.intellij.psi.search.SingleTargetRequestResultProcessor
 import com.intellij.psi.search.UsageSearchContext
 import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.xml.XmlTag
 import com.intellij.util.Processor
 import com.intellij.util.QueryExecutor
 import dev.blachut.svelte.lang.SvelteFileType
@@ -17,20 +25,71 @@ class SvelteReferenceSearch : QueryExecutor<PsiReference, ReferencesSearch.Searc
         ReadAction.run<RuntimeException> {
             val elementToSearch = queryParameters.elementToSearch
             val containingFile = elementToSearch.containingFile
-            if (elementToSearch is ES6ImportedBinding && containingFile.virtualFile.fileType is SvelteFileType) {
-                val componentName = elementToSearch.name
-                if (componentName != null) {
+            if (containingFile.virtualFile.fileType is SvelteFileType) {
+                if (elementToSearch is ES6ImportedBinding) {
+                    val componentName = (elementToSearch as JSNamedElement).name
+                    if (componentName != null) {
+                        queryParameters.optimizer.searchWord(
+                            componentName,
+                            LocalSearchScope(containingFile),
+                            UsageSearchContext.IN_CODE,
+                            true,
+                            elementToSearch,
+                            SingleTargetRequestResultProcessor(elementToSearch)
+                        )
+                    }
+                }
+                if (elementToSearch is ES6ImportSpecifierAlias) {
+                    val componentName = (elementToSearch as ES6ImportExportSpecifierAlias).qualifiedName
+                    if (componentName != null) {
+                        queryParameters.optimizer.searchWord(
+                            componentName,
+                            LocalSearchScope(containingFile),
+                            UsageSearchContext.IN_CODE,
+                            true,
+                            elementToSearch,
+                            MyProcessor(elementToSearch)
+                        )
+                    }
+                }
+            }
+            if (elementToSearch is ES6ExportSpecifierAlias && queryParameters.effectiveSearchScope is LocalSearchScope) {
+                val qualifiedName = elementToSearch.qualifiedName
+                if (qualifiedName != null) {
+                    val scope = (queryParameters.effectiveSearchScope as LocalSearchScope).scope.firstOrNull() ?: return@run
                     queryParameters.optimizer.searchWord(
-                        componentName,
-                        LocalSearchScope(containingFile),
+                        qualifiedName,
+                        LocalSearchScope(scope.containingFile),
                         UsageSearchContext.IN_CODE,
                         true,
                         elementToSearch,
-                        SingleTargetRequestResultProcessor(elementToSearch)
+                        MyProcessor(elementToSearch)
                     )
                 }
             }
         }
         return true
+    }
+
+
+
+    private class MyProcessor(private val target: PsiElement) : RequestResultProcessor(target) {
+        override fun processTextOccurrence(element: PsiElement, offsetInElement: Int, consumer: Processor<in PsiReference>): Boolean {
+            if (!target.isValid) {
+                return false
+            }
+
+            val alias = target as ES6ImportExportSpecifierAlias
+
+            if (element is XmlTag) {
+                if (element.name == alias.name) {
+                    val references = PsiReferenceService.getService().getReferences(element, PsiReferenceService.Hints(target, offsetInElement))
+                    references.forEach {ref ->
+                        consumer.process(ref)
+                    }
+                }
+            }
+            return true
+        }
     }
 }

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/Visitors.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/Visitors.kt
@@ -1,5 +1,6 @@
 package dev.blachut.svelte.lang.codeInsight
 
+import com.intellij.lang.ecmascript6.psi.ES6ImportSpecifier
 import com.intellij.lang.ecmascript6.psi.ES6ImportedBinding
 import com.intellij.lang.javascript.psi.JSElement
 import com.intellij.lang.javascript.psi.JSElementVisitor
@@ -16,7 +17,7 @@ import com.intellij.xml.util.HtmlUtil
 
 internal class ImportVisitor : JSElementVisitor() {
     val components = mutableListOf<String>()
-    val bindings = mutableListOf<ES6ImportedBinding>()
+    val bindings = mutableListOf<JSElement>()
 
     override fun visitES6ImportedBinding(importedBinding: ES6ImportedBinding) {
         val name = importedBinding.name ?: return
@@ -24,6 +25,15 @@ internal class ImportVisitor : JSElementVisitor() {
         if (StringUtil.isCapitalized(name)) {
             components.add(name)
             bindings.add(importedBinding)
+        }
+    }
+
+    override fun visitImportSpecifier(importSpecifier: ES6ImportSpecifier?) {
+        val name = importSpecifier?.name ?: return
+
+        if (StringUtil.isCapitalized(name)) {
+            components.add(name)
+            bindings.add(importSpecifier)
         }
     }
 

--- a/src/main/java/dev/blachut/svelte/lang/completion/SvelteInsertHandler.kt
+++ b/src/main/java/dev/blachut/svelte/lang/completion/SvelteInsertHandler.kt
@@ -19,7 +19,7 @@ class SvelteInsertHandler : InsertHandler<LookupElement> {
             replaceWithLiveTemplate(lookupObject.props, context, componentName)
         }
 
-        ComponentImporter.insertComponentImport(context.editor, context.file, lookupObject.file, componentName)
+        ComponentImporter.insertComponentImport(context.editor, context.file, lookupObject.file, componentName, lookupObject.moduleInfo)
     }
 
     private fun replaceWithLiveTemplate(props: List<String?>, context: InsertionContext, componentName: String) {

--- a/src/main/java/dev/blachut/svelte/lang/inspections/SvelteUnresolvedComponentInspection.kt
+++ b/src/main/java/dev/blachut/svelte/lang/inspections/SvelteUnresolvedComponentInspection.kt
@@ -29,20 +29,21 @@ class SvelteUnresolvedComponentInspection : LocalInspectionTool() {
                 if (files.isEmpty()) return
 
                 files.forEach {
-                    val quickFix = object : LocalQuickFix {
-                        override fun getFamilyName(): String {
-                            val moduleInfo = ComponentImporter.getModuleInfo(tag.project, tag.containingFile, it, componentName)
-                            return ComponentImporter.getImportText(tag.containingFile, it, componentName, moduleInfo)
-                        }
+                    val modulesInfos = ComponentImporter.getModulesInfos(tag.project, tag.containingFile, it, componentName)
+                    modulesInfos.forEach { info ->
+                        val quickFix = object : LocalQuickFix {
+                            override fun getFamilyName(): String {
+                                return ComponentImporter.getImportText(tag.containingFile, it, componentName, info)
+                            }
 
-                        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-                            val editor = PsiEditorUtil.Service.getInstance().findEditorByPsiElement(tag)
-                                ?: return
-                            ComponentImporter.insertComponentImport(editor, tag.containingFile, it, componentName)
+                            override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                                val editor = PsiEditorUtil.Service.getInstance().findEditorByPsiElement(tag)
+                                    ?: return
+                                ComponentImporter.insertComponentImport(editor, tag.containingFile, it, componentName, info)
+                            }
                         }
+                        holder.registerProblem(tag, displayName, quickFix)
                     }
-
-                    holder.registerProblem(tag, displayName, quickFix)
                 }
             }
         }

--- a/src/main/java/dev/blachut/svelte/lang/inspections/SvelteUnresolvedComponentInspection.kt
+++ b/src/main/java/dev/blachut/svelte/lang/inspections/SvelteUnresolvedComponentInspection.kt
@@ -31,7 +31,8 @@ class SvelteUnresolvedComponentInspection : LocalInspectionTool() {
                 files.forEach {
                     val quickFix = object : LocalQuickFix {
                         override fun getFamilyName(): String {
-                            return ComponentImporter.getImportText(tag.containingFile, it, componentName)
+                            val moduleInfo = ComponentImporter.getModuleInfo(tag.project, tag.containingFile, it, componentName)
+                            return ComponentImporter.getImportText(tag.containingFile, it, componentName, moduleInfo)
                         }
 
                         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {


### PR DESCRIPTION
This is a way to handle aliased re-exports from project files as well as from node_modules (related to #37 #6)

![image](https://user-images.githubusercontent.com/793712/61973900-20891a00-afdd-11e9-905f-a6d8fdbb57e9.png)

Todo:
- [x] insert into existing imports

![image](https://user-images.githubusercontent.com/793712/61979781-b7110780-afec-11e9-9024-97c86a0edf68.png)

- [x] search svelte files re-exports and add to lookup elements
![image](https://user-images.githubusercontent.com/793712/61984452-5a1d4d80-affc-11e9-9f1a-ac25b456e848.png)
![image](https://user-images.githubusercontent.com/793712/61984468-65707900-affc-11e9-80cd-f8d411af547b.png)



It's a bit messy, if you'd like to take what's useful, it will be fine
The hardest part is to find which API to use as there's not enough documentation


---
Resolves #6 
Resolves #37 