### PR TITLE
Enable completion of css from the same svelte component

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/css/SvelteCssInclusionContext.kt
+++ b/src/main/java/dev/blachut/svelte/lang/css/SvelteCssInclusionContext.kt
@@ -1,0 +1,11 @@
+package dev.blachut.svelte.lang.css
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.css.resolve.CssInclusionContext
+import dev.blachut.svelte.lang.SvelteHTMLLanguage
+
+
+class SvelteCssInclusionContext : CssInclusionContext() {
+    override fun processAllCssFilesOnResolving(context: PsiElement): Boolean =
+        context.containingFile?.language is SvelteHTMLLanguage
+}

--- a/src/main/java/dev/blachut/svelte/lang/css/SvelteEmbeddedCssProvider.kt
+++ b/src/main/java/dev/blachut/svelte/lang/css/SvelteEmbeddedCssProvider.kt
@@ -1,0 +1,9 @@
+package dev.blachut.svelte.lang.css
+
+import com.intellij.lang.Language
+import com.intellij.psi.css.EmbeddedCssProvider
+import dev.blachut.svelte.lang.SvelteHTMLLanguage
+
+class SvelteEmbeddedCssProvider : EmbeddedCssProvider() {
+    override fun enableEmbeddedCssFor(language: Language): Boolean = language is SvelteHTMLLanguage
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,6 +79,7 @@
                          groupKey="html.inspections.group.name"
                          implementationClass="dev.blachut.svelte.lang.inspections.SvelteUnresolvedComponentInspection"/>
         <css.embeddedCssProvider implementation="dev.blachut.svelte.lang.css.SvelteEmbeddedCssProvider"/>
+        <css.inclusionContext implementation="dev.blachut.svelte.lang.css.SvelteCssInclusionContext"/>
     </extensions>
     <extensions defaultExtensionNs="JavaScript">
         <dialectSpecificHandlersFactory language="SvelteJS"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -78,6 +78,7 @@
                          bundle="messages.XmlBundle"
                          groupKey="html.inspections.group.name"
                          implementationClass="dev.blachut.svelte.lang.inspections.SvelteUnresolvedComponentInspection"/>
+        <css.embeddedCssProvider implementation="dev.blachut.svelte.lang.css.SvelteEmbeddedCssProvider"/>
     </extensions>
     <extensions defaultExtensionNs="JavaScript">
         <dialectSpecificHandlersFactory language="SvelteJS"


### PR DESCRIPTION
Related to #60. 

I will try to dug deeper to enable support for css from separate `.css` files. 
As far as I understand, `<style>` in svelte component is local to component, so there is no need to add completion from neighbour svelte components.