### PR TITLE
don't use `BaseHtmlLexer.ourDefaultStyleLanguage`

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlHighlightingLexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlHighlightingLexer.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.javascript.JavaScriptHighlightingLexer
 import com.intellij.lang.javascript.dialects.JSLanguageLevel
 import com.intellij.lexer.HtmlHighlightingLexer
 import com.intellij.lexer.LayeredLexer
+import com.intellij.lang.css.CSSLanguage
 import com.intellij.psi.tree.IElementType
 import dev.blachut.svelte.lang.parsing.js.SvelteJSScriptContentProvider
 import dev.blachut.svelte.lang.psi.SvelteTypes
@@ -46,5 +47,5 @@ private open class BaseSvelteHtmlHighlightingLexer : HtmlHighlightingLexer(Inner
     }
 
     override fun getStyleLanguage(): Language? =
-        helper.styleViaLang(ourDefaultStyleLanguage) ?: super.getStyleLanguage()
+        helper.styleViaLang(CSSLanguage.INSTANCE) ?: super.getStyleLanguage()
 }

--- a/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlLexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlLexer.kt
@@ -3,6 +3,7 @@ package dev.blachut.svelte.lang.parsing.html
 import com.intellij.lang.Language
 import com.intellij.lexer.HtmlHighlightingLexer
 import com.intellij.lexer.HtmlLexer
+import com.intellij.lang.css.CSSLanguage
 import com.intellij.psi.tree.IElementType
 import dev.blachut.svelte.lang.parsing.js.SvelteJSScriptContentProvider
 
@@ -46,7 +47,7 @@ class SvelteHtmlLexer : HtmlLexer(InnerSvelteHtmlLexer(), false) {
     override fun findScriptContentProvider(mimeType: String?) = SvelteJSScriptContentProvider
 
     override fun getStyleLanguage(): Language? =
-        helper.styleViaLang(ourDefaultStyleLanguage) ?: super.getStyleLanguage()
+        helper.styleViaLang(CSSLanguage.INSTANCE) ?: super.getStyleLanguage()
 
     override fun isHtmlTagState(state: Int): Boolean {
         return state == _SvelteHtmlLexer.START_TAG_NAME || state == _SvelteHtmlLexer.END_TAG_NAME


### PR DESCRIPTION
`BaseHtmlLexer.ourDefaultStyleLanguage` will not be available in 2020.2.
Replaced with direct usage of `CSSLanguage.INSTANCE`, which is 100% equivalent.