### PR TITLE
Bump PsiViewer version for compatibility with 2020.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,12 @@ plugins {
 apply plugin: "kotlin"
 
 group 'dev.blachut.svelte.lang'
-version '0.12.1'
+version '0.12.2'
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version 'IU-LATEST-EAP-SNAPSHOT'
-    plugins = ['JavaScriptLanguage', 'CSS', 'PsiViewer:201.3803.71-EAP-SNAPSHOT.1']
+    plugins = ['JavaScriptLanguage', 'CSS', 'PsiViewer:202-SNAPSHOT.3']
 }
 
 patchPluginXml {

--- a/src/main/java/dev/blachut/svelte/lang/actions/SvelteCreateComponentAction.kt
+++ b/src/main/java/dev/blachut/svelte/lang/actions/SvelteCreateComponentAction.kt
@@ -15,7 +15,7 @@ class SvelteCreateComponentAction : CreateFileFromTemplateAction(NAME, DESCRIPTI
         private const val DESCRIPTION = "Creates Svelte component file"
     }
 
-    override fun buildDialog(project: Project?, directory: PsiDirectory?, builder: CreateFileFromTemplateDialog.Builder) {
+    override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
         builder
             .setTitle("New $NAME")
             .addKind(NAME, SvelteIcons.FILE, TEMPLATE_NAME)

--- a/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlHighlightingLexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlHighlightingLexer.kt
@@ -1,6 +1,7 @@
 package dev.blachut.svelte.lang.parsing.html
 
 import com.intellij.lang.Language
+import com.intellij.lang.css.CSSLanguage
 import com.intellij.lang.javascript.JavaScriptHighlightingLexer
 import com.intellij.lang.javascript.dialects.JSLanguageLevel
 import com.intellij.lexer.HtmlHighlightingLexer
@@ -46,5 +47,5 @@ private open class BaseSvelteHtmlHighlightingLexer : HtmlHighlightingLexer(Inner
     }
 
     override fun getStyleLanguage(): Language? =
-        helper.styleViaLang(ourDefaultStyleLanguage) ?: super.getStyleLanguage()
+        helper.styleViaLang(CSSLanguage.INSTANCE) ?: super.getStyleLanguage()
 }

--- a/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlLexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlLexer.kt
@@ -1,6 +1,7 @@
 package dev.blachut.svelte.lang.parsing.html
 
 import com.intellij.lang.Language
+import com.intellij.lang.css.CSSLanguage
 import com.intellij.lexer.HtmlHighlightingLexer
 import com.intellij.lexer.HtmlLexer
 import com.intellij.psi.tree.IElementType
@@ -46,7 +47,7 @@ class SvelteHtmlLexer : HtmlLexer(InnerSvelteHtmlLexer(), false) {
     override fun findScriptContentProvider(mimeType: String?) = SvelteJSScriptContentProvider
 
     override fun getStyleLanguage(): Language? =
-        helper.styleViaLang(ourDefaultStyleLanguage) ?: super.getStyleLanguage()
+        helper.styleViaLang(CSSLanguage.INSTANCE) ?: super.getStyleLanguage()
 
     override fun isHtmlTagState(state: Int): Boolean {
         return state == _SvelteHtmlLexer.START_TAG_NAME || state == _SvelteHtmlLexer.END_TAG_NAME

--- a/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlParsing.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlParsing.kt
@@ -1,6 +1,6 @@
 package dev.blachut.svelte.lang.parsing.html
 
-import com.intellij.codeInsight.daemon.XmlErrorMessages
+import com.intellij.codeInsight.daemon.XmlErrorBundle
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.html.HtmlParsing
 import com.intellij.psi.TokenType
@@ -72,7 +72,7 @@ class SvelteHtmlParsing(builder: PsiBuilder) : HtmlParsing(builder) {
                 if (tt === XmlTokenType.XML_BAD_CHARACTER) {
                     val error = mark()
                     advance()
-                    error.error(XmlErrorMessages.message("unescaped.ampersand.or.nonterminated.character.entity.reference"))
+                    error.error(XmlErrorBundle.message("unescaped.ampersand.or.nonterminated.character.entity.reference"))
                 } else if (tt === XmlTokenType.XML_ENTITY_REF_TOKEN) {
                     parseReference()
                 } else if (isRemappedStartMustache()) {
@@ -85,7 +85,7 @@ class SvelteHtmlParsing(builder: PsiBuilder) : HtmlParsing(builder) {
             if (token() === XmlTokenType.XML_ATTRIBUTE_VALUE_END_DELIMITER) {
                 advance()
             } else {
-                error(XmlErrorMessages.message("xml.parsing.unclosed.attribute.value"))
+                error(XmlErrorBundle.message("xml.parsing.unclosed.attribute.value"))
             }
         } else {
             // Unquoted attr value. Unlike unmodified IntelliJ HTML this isn't necessary single token


### PR DESCRIPTION
Bump PsiViewer version for compatibility with 2020.2

Replase removed in 2020.2 BaseHtmlLexer.ourDefaultStyleLanguage and deprecated XmlErrorMessages to XmlErrorBundle