### PR TITLE
Support Find Usages for subscribed stores

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/SvelteFrameworkHandler.kt
+++ b/src/main/java/dev/blachut/svelte/lang/SvelteFrameworkHandler.kt
@@ -1,0 +1,34 @@
+package dev.blachut.svelte.lang
+
+import com.intellij.lang.javascript.index.FrameworkIndexingHandler
+import com.intellij.lang.javascript.psi.JSFunctionType
+import com.intellij.lang.javascript.psi.JSVariable
+import com.intellij.lang.javascript.psi.resolve.JSEvaluateContext
+import com.intellij.lang.javascript.psi.resolve.JSTypeEvaluator
+import com.intellij.psi.PsiElement
+import dev.blachut.svelte.lang.psi.SvelteJSReferenceExpression
+
+class SvelteFrameworkHandler : FrameworkIndexingHandler() {
+    override fun addTypeFromResolveResult(
+        evaluator: JSTypeEvaluator,
+        context: JSEvaluateContext,
+        result: PsiElement
+    ): Boolean {
+        val expression = context.processedExpression
+        if (result is JSVariable && expression is SvelteJSReferenceExpression && expression.isSubscribedReference) {
+            try {
+                val storeType = result.jsType?.asRecordType() ?: return false
+                val subscribeMethod =
+                    storeType.findPropertySignature("subscribe")?.jsType as? JSFunctionType ?: return false
+                val subscriberFunction =
+                    subscribeMethod.parameters[0].inferredType?.substitute() as? JSFunctionType ?: return false
+                val storeContentType = subscriberFunction.parameters[0].inferredType ?: return false
+
+                evaluator.addType(storeContentType, expression)
+                return true
+            } catch (e: Exception) {
+            }
+        }
+        return false
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteJSReferenceExpressionResolver.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteJSReferenceExpressionResolver.kt
@@ -2,7 +2,6 @@
 package dev.blachut.svelte.lang.codeInsight
 
 import com.intellij.lang.javascript.index.JSSymbolUtil
-import com.intellij.lang.javascript.psi.JSReferenceExpression
 import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
 import com.intellij.lang.javascript.psi.resolve.JSReferenceExpressionResolver
 import com.intellij.lang.javascript.psi.resolve.JSResolveResult
@@ -16,14 +15,6 @@ class SvelteJSReferenceExpressionResolver(
 ) :
     JSReferenceExpressionResolver(referenceExpression, ignorePerformanceLimits) {
     private val implicitIdentifiers = arrayOf("\$\$props", "\$\$restProps", "\$\$slots")
-
-    override fun adjustReferencedName(expression: JSReferenceExpression): String? {
-        val name = expression.referenceName
-        if (name != null && expression.qualifier == null && name.length > 1 && name[0] == '$' && name[1] != '$') {
-            return name.substring(1)
-        }
-        return name
-    }
 
     override fun resolve(expression: JSReferenceExpressionImpl, incompleteCode: Boolean): Array<ResolveResult> {
         implicitIdentifiers.forEach {

--- a/src/main/java/dev/blachut/svelte/lang/editor/SvelteSubscribedReferenceSelectionFilter.kt
+++ b/src/main/java/dev/blachut/svelte/lang/editor/SvelteSubscribedReferenceSelectionFilter.kt
@@ -1,0 +1,13 @@
+package dev.blachut.svelte.lang.editor
+
+import com.intellij.lang.javascript.JSTokenTypes
+import com.intellij.openapi.util.Condition
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import dev.blachut.svelte.lang.psi.SvelteJSReferenceExpression
+
+class SvelteSubscribedReferenceSelectionFilter : Condition<PsiElement> {
+    override fun value(e: PsiElement): Boolean {
+        return !(e.elementType == JSTokenTypes.IDENTIFIER && SvelteJSReferenceExpression.isDollarPrefixedName(e.text))
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/editor/SvelteSubscribedReferenceSelectioner.kt
+++ b/src/main/java/dev/blachut/svelte/lang/editor/SvelteSubscribedReferenceSelectioner.kt
@@ -1,0 +1,32 @@
+package dev.blachut.svelte.lang.editor
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.lang.javascript.JSTokenTypes
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import dev.blachut.svelte.lang.psi.SvelteJSReferenceExpression
+
+class SvelteSubscribedReferenceSelectioner : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement): Boolean {
+        return e.elementType == JSTokenTypes.IDENTIFIER && SvelteJSReferenceExpression.isDollarPrefixedName(e.text)
+    }
+
+    override fun select(
+        e: PsiElement,
+        editorText: CharSequence,
+        cursorOffset: Int,
+        editor: Editor
+    ): List<TextRange> {
+        val originalTextRange = e.textRange
+        val list = mutableListOf(originalTextRange)
+        list.add(TextRange.create(originalTextRange.startOffset + 1, originalTextRange.endOffset))
+
+        return list
+    }
+
+    override fun getMinimalTextRangeLength(element: PsiElement, text: CharSequence, cursorOffset: Int): Int {
+        return element.textLength - 1
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/index/SvelteFilterLexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/index/SvelteFilterLexer.kt
@@ -1,0 +1,94 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package dev.blachut.svelte.lang.index
+
+import com.intellij.lang.Language
+import com.intellij.lang.html.HTMLLanguage
+import com.intellij.lang.javascript.JSExtendedLanguagesTokenSetProvider
+import com.intellij.lang.javascript.JSKeywordSets
+import com.intellij.lang.javascript.JSTokenTypes
+import com.intellij.lang.xml.XMLLanguage
+import com.intellij.lexer.Lexer
+import com.intellij.psi.impl.cache.CacheUtil
+import com.intellij.psi.impl.cache.impl.BaseFilterLexer
+import com.intellij.psi.impl.cache.impl.OccurrenceConsumer
+import com.intellij.psi.impl.cache.impl.idCache.XmlFilterLexer
+import com.intellij.psi.search.UsageSearchContext
+import com.intellij.psi.tree.TokenSet.create
+import com.intellij.psi.tree.TokenSet.orSet
+import com.intellij.psi.xml.XmlTokenType
+import com.intellij.util.containers.ContainerUtil
+import dev.blachut.svelte.lang.SvelteHTMLLanguage
+import dev.blachut.svelte.lang.SvelteJSLanguage
+import kotlin.experimental.or
+
+class SvelteFilterLexer(occurrenceConsumer: OccurrenceConsumer, originalLexer: Lexer) :
+    BaseFilterLexer(originalLexer, occurrenceConsumer) {
+    override fun advance() {
+        val tokenType = myDelegate.tokenType
+        if (!SKIP_WORDS.contains(tokenType)) {
+            if (IDENTIFIERS.contains(tokenType)) {
+                addOccurrenceInToken(UsageSearchContext.IN_CODE.toInt())
+            }
+            // TODO support directives, refer to Vue plugin
+            // else if (tokenType === XML_NAME) { }
+            else if (tokenType === XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN ||
+                tokenType === XmlTokenType.XML_NAME ||
+                tokenType === XmlTokenType.XML_TAG_NAME ||
+                tokenType === XmlTokenType.XML_DATA_CHARACTERS
+            ) {
+                scanWordsInToken(
+                    (UsageSearchContext.IN_PLAIN_TEXT or UsageSearchContext.IN_FOREIGN_LANGUAGES).toInt(),
+                    tokenType === XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN,
+                    false
+                )
+            } else if (COMMENTS.contains(tokenType)) {
+                scanWordsInToken(UsageSearchContext.IN_COMMENTS.toInt(), false, false)
+                advanceTodoItemCountsInToken()
+            } else if (LITERALS.contains(tokenType)) {
+                scanWordsInToken(UsageSearchContext.IN_STRINGS.toInt(), false, false)
+            } else if (tokenType != null && !SUPPORTED_LANGUAGES.contains(tokenType.language)) {
+                val inComments = CacheUtil.isInComments(tokenType)
+                scanWordsInToken(
+                    (if (inComments) UsageSearchContext.IN_COMMENTS else UsageSearchContext.IN_PLAIN_TEXT or UsageSearchContext.IN_FOREIGN_LANGUAGES).toInt(),
+                    true,
+                    false
+                )
+
+                if (inComments) advanceTodoItemCountsInToken()
+            } else {
+                scanWordsInToken(UsageSearchContext.IN_PLAIN_TEXT.toInt(), false, false)
+            }
+        }
+
+        myDelegate.advance()
+    }
+
+    companion object {
+        private val SUPPORTED_LANGUAGES = ContainerUtil.newHashSet(
+            XMLLanguage.INSTANCE,
+            HTMLLanguage.INSTANCE,
+            SvelteHTMLLanguage.INSTANCE,
+            SvelteJSLanguage.INSTANCE,
+            Language.ANY
+        )
+
+        private val IDENTIFIERS = orSet(
+            JSKeywordSets.IDENTIFIER_NAMES
+        )
+
+        private val COMMENTS = orSet(
+            JSTokenTypes.COMMENTS,
+            create(XmlTokenType.XML_COMMENT_CHARACTERS)
+        )
+
+        private val LITERALS = orSet(
+            JSTokenTypes.LITERALS
+        )
+
+        private val SKIP_WORDS = orSet(
+            JSExtendedLanguagesTokenSetProvider.SKIP_WORDS_SCAN_SET,
+            XmlFilterLexer.NO_WORDS_TOKEN_SET,
+            create(XmlTokenType.XML_COMMA)
+        )
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/index/SvelteFilterLexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/index/SvelteFilterLexer.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.xml.XmlTokenType
 import com.intellij.util.containers.ContainerUtil
 import dev.blachut.svelte.lang.SvelteHTMLLanguage
 import dev.blachut.svelte.lang.SvelteJSLanguage
+import dev.blachut.svelte.lang.psi.SvelteJSReferenceExpression
 import kotlin.experimental.or
 
 class SvelteFilterLexer(occurrenceConsumer: OccurrenceConsumer, originalLexer: Lexer) :
@@ -27,7 +28,10 @@ class SvelteFilterLexer(occurrenceConsumer: OccurrenceConsumer, originalLexer: L
         val tokenType = myDelegate.tokenType
         if (!SKIP_WORDS.contains(tokenType)) {
             if (IDENTIFIERS.contains(tokenType)) {
-                addOccurrenceInToken(UsageSearchContext.IN_CODE.toInt())
+                val subscribedStore = SvelteJSReferenceExpression.isDollarPrefixedName(tokenText)
+                val start = if (subscribedStore) 1 else 0
+                val length = if (subscribedStore) tokenText.length - tokenText.length else tokenText.length
+                addOccurrenceInToken(UsageSearchContext.IN_CODE.toInt(), start, length)
             }
             // TODO support directives, refer to Vue plugin
             // else if (tokenType === XML_NAME) { }

--- a/src/main/java/dev/blachut/svelte/lang/index/SvelteIdIndexer.kt
+++ b/src/main/java/dev/blachut/svelte/lang/index/SvelteIdIndexer.kt
@@ -1,0 +1,25 @@
+package dev.blachut.svelte.lang.index
+
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+import com.intellij.psi.impl.cache.impl.BaseFilterLexerUtil
+import com.intellij.psi.impl.cache.impl.id.IdIndexEntry
+import com.intellij.psi.impl.cache.impl.id.LexingIdIndexer
+import com.intellij.util.indexing.FileContent
+import dev.blachut.svelte.lang.SvelteHTMLLanguage
+
+class SvelteIdIndexer : LexingIdIndexer {
+    override fun map(inputData: FileContent): Map<IdIndexEntry, Int> {
+        return BaseFilterLexerUtil.scanContent(inputData) { consumer ->
+            SvelteFilterLexer(
+                consumer,
+                SyntaxHighlighterFactory.getSyntaxHighlighter(
+                    SvelteHTMLLanguage.INSTANCE, inputData.project, inputData.file
+                ).highlightingLexer
+            )
+        }.idMap
+    }
+
+    override fun getVersion(): Int {
+        return 1
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/parsing/js/ElementTypeRemappingPsiBuilder.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/js/ElementTypeRemappingPsiBuilder.kt
@@ -1,0 +1,32 @@
+package dev.blachut.svelte.lang.parsing.js
+
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.impl.DelegateMarker
+import com.intellij.lang.impl.PsiBuilderAdapter
+import com.intellij.psi.tree.IElementType
+
+abstract class ElementTypeRemappingPsiBuilder(delegate: PsiBuilder) : PsiBuilderAdapter(delegate) {
+    abstract fun remapElementType(type: IElementType): IElementType
+
+    override fun mark(): PsiBuilder.Marker {
+        return RemappingMarker(super.mark())
+    }
+
+    inner class RemappingMarker(delegate: PsiBuilder.Marker) : DelegateMarker(delegate) {
+        override fun done(type: IElementType) {
+            super.done(remapElementType(type))
+        }
+
+        override fun collapse(type: IElementType) {
+            super.collapse(remapElementType(type))
+        }
+
+        override fun doneBefore(type: IElementType, before: PsiBuilder.Marker) {
+            super.doneBefore(remapElementType(type), before)
+        }
+
+        override fun doneBefore(type: IElementType, before: PsiBuilder.Marker, errorMessage: String) {
+            super.doneBefore(remapElementType(type), before, errorMessage)
+        }
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/parsing/js/SvelteJSParser.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/js/SvelteJSParser.kt
@@ -7,19 +7,11 @@ import com.intellij.lang.ecmascript6.parsing.ES6Parser
 import com.intellij.lang.ecmascript6.parsing.ES6StatementParser
 import com.intellij.lang.javascript.JSTokenTypes
 import com.intellij.lang.javascript.parsing.JSPsiTypeParser
-import com.intellij.psi.tree.IElementType
 import dev.blachut.svelte.lang.SvelteJSLanguage
 
 class SvelteJSParser(builder: PsiBuilder) : ES6Parser<ES6ExpressionParser<*>, ES6StatementParser<*>,
-    ES6FunctionParser<*>, JSPsiTypeParser<*>>(SvelteJSLanguage.INSTANCE, builder) {
+    ES6FunctionParser<*>, JSPsiTypeParser<*>>(SvelteJSLanguage.INSTANCE, SvelteJSPsiBuilder(builder)) {
     init {
-        myStatementParser = object : ES6StatementParser<SvelteJSParser>(this) {
-            override fun getVariableElementType(): IElementType {
-                // TODO Try to crate lazy element that splits variable and $ prefix
-                return super.getVariableElementType()
-            }
-        }
-
         myExpressionParser = object : ES6ExpressionParser<SvelteJSParser>(this) {
             override fun getCurrentBinarySignPriority(allowIn: Boolean, advance: Boolean): Int {
                 if (this.builder.tokenType === JSTokenTypes.AS_KEYWORD) {

--- a/src/main/java/dev/blachut/svelte/lang/parsing/js/SvelteJSPsiBuilder.kt
+++ b/src/main/java/dev/blachut/svelte/lang/parsing/js/SvelteJSPsiBuilder.kt
@@ -1,0 +1,16 @@
+package dev.blachut.svelte.lang.parsing.js
+
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.javascript.JSElementTypes
+import com.intellij.psi.tree.IElementType
+import dev.blachut.svelte.lang.psi.SvelteJSElementTypes
+
+class SvelteJSPsiBuilder(delegate: PsiBuilder) : ElementTypeRemappingPsiBuilder(delegate) {
+    override fun remapElementType(type: IElementType): IElementType {
+        return if (type === JSElementTypes.REFERENCE_EXPRESSION) {
+            SvelteJSElementTypes.REFERENCE_EXPRESSION
+        } else {
+            type
+        }
+    }
+}

--- a/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSElementTypes.kt
+++ b/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSElementTypes.kt
@@ -1,17 +1,25 @@
 package dev.blachut.svelte.lang.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.lang.javascript.JSCompositeElementType
 import com.intellij.lang.javascript.types.JSEmbeddedContentElementType
+import com.intellij.lang.javascript.types.JSExpressionElementType
 import com.intellij.lang.javascript.types.JSParameterElementType
+import com.intellij.psi.tree.IElementType
 import dev.blachut.svelte.lang.SvelteJSLanguage
 
 object SvelteJSElementTypes {
     val PARAMETER = object : JSParameterElementType("EMBEDDED_PARAMETER") {
         override fun construct(node: ASTNode) = SvelteJSParameter(node)
 
-        override fun toString(): String {
-            return "Svelte" + super.toString()
-        }
+        override fun toString(): String = "Svelte" + super.toString()
+    }
+
+    val REFERENCE_EXPRESSION: IElementType = object : JSCompositeElementType("SVELTE_JS_REFERENCE_EXPRESSION"),
+        JSExpressionElementType {
+        override fun createCompositeNode() = SvelteJSReferenceExpression(this)
+
+        override fun toString(): String = "Svelte" + super.toString()
     }
 
     val EMBEDDED_CONTENT_MODULE = object : JSEmbeddedContentElementType(SvelteJSLanguage.INSTANCE, "MOD_SVELTE_JS_") {

--- a/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSReferenceExpression.kt
+++ b/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSReferenceExpression.kt
@@ -1,0 +1,47 @@
+package dev.blachut.svelte.lang.psi
+
+import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
+import com.intellij.refactoring.rename.FragmentaryPsiReference
+
+class SvelteJSReferenceExpression(elementType: IElementType) : JSReferenceExpressionImpl(elementType),
+    FragmentaryPsiReference {
+    val isSubscribedReference: Boolean
+        get() = qualifier == null && super.getReferencedName()?.let(::isDollarPrefixedName) ?: false
+
+    override fun isReadOnlyFragment(): Boolean {
+        return false
+    }
+
+    override fun isFragmentOnlyRename(): Boolean {
+        return isSubscribedReference
+    }
+
+    override fun getReferencedName(): String? {
+        val name = super.getReferencedName()
+        return if (name != null && qualifier == null && isDollarPrefixedName(name)) name.substring(1) else name
+    }
+
+    override fun getCanonicalText(): String {
+        val name = super.getCanonicalText()
+        return if (isDollarPrefixedName(name)) name.substring(1) else name
+    }
+
+    override fun getRangeInElement(): TextRange {
+        val range = super.getRangeInElement()
+        return if (isSubscribedReference) TextRange(range.startOffset + 1, range.endOffset) else range
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement {
+        val correctedName = if (isSubscribedReference) "\$$newElementName" else newElementName
+        return super.handleElementRename(correctedName)
+    }
+
+    companion object {
+        fun isDollarPrefixedName(name: String): Boolean {
+            return name.length > 1 && name[0] == '$' && name[1] != '$'
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,7 @@
         <xml.elementDescriptorProvider implementation="dev.blachut.svelte.lang.codeInsight.SvelteTagProvider"/>
         <html.scriptContentProvider language="SvelteJS"
                                     implementationClass="dev.blachut.svelte.lang.parsing.js.SvelteJSScriptContentProvider"/>
+        <idIndexer filetype="Svelte" implementationClass="dev.blachut.svelte.lang.index.SvelteIdIndexer"/>
         <referencesSearch implementation="dev.blachut.svelte.lang.codeInsight.SvelteReferencesSearch" order="first"/>
         <completion.contributor language="any"
                                 implementationClass="dev.blachut.svelte.lang.completion.SvelteCompletionContributor"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,5 +72,6 @@
                                         implementationClass="dev.blachut.svelte.lang.SvelteJSSpecificHandlersFactory"/>
         <analysisHandlersFactory language="SvelteJS"
                                  implementationClass="dev.blachut.svelte.lang.SvelteJSAnalysisHandlersFactory"/>
+        <frameworkIndexingHandler implementation="dev.blachut.svelte.lang.SvelteFrameworkHandler" version="1"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,10 @@
         <lang.formatter language="SvelteHTML"
                         implementationClass="dev.blachut.svelte.lang.format.SvelteFormattingModelBuilder"/>
         <extendWordSelectionHandler implementation="dev.blachut.svelte.lang.editor.SveltePrimaryBranchSelectioner"/>
+        <extendWordSelectionHandler
+            implementation="dev.blachut.svelte.lang.editor.SvelteSubscribedReferenceSelectioner"/>
+        <basicWordSelectionFilter
+            implementation="dev.blachut.svelte.lang.editor.SvelteSubscribedReferenceSelectionFilter"/>
         <multiLangCommenter implementation="dev.blachut.svelte.lang.editor.SvelteCommentProvider"/>
         <typedHandler implementation="dev.blachut.svelte.lang.editor.SvelteTagEndTypedHandler" order="before xmlSlash"/>
         <typedHandler implementation="dev.blachut.svelte.lang.editor.SvelteBraceTypedHandler"/>

--- a/src/test/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlParserTest.kt
+++ b/src/test/java/dev/blachut/svelte/lang/parsing/html/SvelteHtmlParserTest.kt
@@ -90,18 +90,21 @@ class SvelteHtmlParserTest : ParsingTestCase(
     fun testHtmlAutoClosingTagsAcrossBlock() = doTest()
     fun testHtmlAutoClosingTagsInsideBlock() = doTest()
 
-    fun testHtmlMissingEndTags() = doTest()
-    fun testHtmlSpecialTags() = doTest()
-
     fun testHtmlClosingTagMatchesNothing1() = doTest()
     fun testHtmlClosingTagMatchesNothing2() = doTest()
     fun testHtmlClosingTagMatchesNothing3() = doTest()
+
+    fun testHtmlMissingEndTags() = doTest()
+    fun testHtmlSpecialTags() = doTest()
 
     fun testHtmlUnclosed1() = doTest()
     fun testHtmlUnclosed2() = doTest()
     fun testHtmlUnclosed3() = doTest()
 
     fun testLet() = doTest()
+
+    fun testQuoteBalanceScriptComment() = doTest()
+    fun testQuoteBalanceUnclosedStringLiteral() = doTest()
 
     fun testStyleTagDefault() = doTest()
     fun testStyleTagScss() = doTest()

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeQuoted.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeQuoted.txt
@@ -15,7 +15,7 @@ SvelteHtmlFile: AttributeQuoted.svelte
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
               JSBinaryExpression
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('title')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:PLUS)('+')
@@ -44,7 +44,7 @@ SvelteHtmlFile: AttributeQuoted.svelte
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
               JSBinaryExpression
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('title')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:PLUS)('+')
@@ -78,7 +78,7 @@ SvelteHtmlFile: AttributeQuoted.svelte
               JSObjectLiteralExpression
                 PsiElement(JS:LBRACE)('{')
                 ES6Property
-                  JSReferenceExpression
+                  SvelteJSReferenceExpression
                     PsiElement(JS:IDENTIFIER)('option')
                 PsiElement(JS:COMMA)(',')
                 PsiWhiteSpace(' ')
@@ -111,14 +111,14 @@ SvelteHtmlFile: AttributeQuoted.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('title')
             PsiElement(END_MUSTACHE)('}')
           XmlToken:XML_ATTRIBUTE_VALUE_TOKEN('infix')
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('second')
             PsiElement(END_MUSTACHE)('}')
           XmlToken:XML_ATTRIBUTE_VALUE_END_DELIMITER('"')
@@ -143,7 +143,7 @@ SvelteHtmlFile: AttributeQuoted.svelte
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
               JSBinaryExpression
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('title')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:PLUS)('+')
@@ -178,7 +178,7 @@ SvelteHtmlFile: AttributeQuoted.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('title')
             PsiElement(END_MUSTACHE)('}')
           XmlToken:XML_ATTRIBUTE_VALUE_END_DELIMITER('"')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeShorthand.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeShorthand.txt
@@ -10,7 +10,7 @@ SvelteHtmlFile: AttributeShorthand.svelte
         SveltePsiElement
           PsiElement(START_MUSTACHE)('{')
           SvelteJS: SPREAD_OR_SHORTHAND
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:IDENTIFIER)('title')
           PsiElement(END_MUSTACHE)('}')
       XmlToken:XML_TAG_END('>')
@@ -28,7 +28,7 @@ SvelteHtmlFile: AttributeShorthand.svelte
         SveltePsiElement
           PsiElement(START_MUSTACHE)('{')
           SvelteJS: SPREAD_OR_SHORTHAND
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:IDENTIFIER)('title')
           PsiElement(END_MUSTACHE)('}')
       PsiWhiteSpace(' ')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeSpread.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeSpread.txt
@@ -12,7 +12,7 @@ SvelteHtmlFile: AttributeSpread.svelte
           SvelteJS: SPREAD_OR_SHORTHAND
             JSSpreadExpression
               PsiElement(JS:DOT_DOT_DOT)('...')
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('props')
           PsiElement(END_MUSTACHE)('}')
       XmlToken:XML_TAG_END('>')
@@ -32,7 +32,7 @@ SvelteHtmlFile: AttributeSpread.svelte
           SvelteJS: SPREAD_OR_SHORTHAND
             JSSpreadExpression
               PsiElement(JS:DOT_DOT_DOT)('...')
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('props')
           PsiElement(END_MUSTACHE)('}')
       PsiWhiteSpace(' ')
@@ -58,7 +58,7 @@ SvelteHtmlFile: AttributeSpread.svelte
               JSObjectLiteralExpression
                 PsiElement(JS:LBRACE)('{')
                 ES6Property
-                  JSReferenceExpression
+                  SvelteJSReferenceExpression
                     PsiElement(JS:IDENTIFIER)('technically')
                 PsiElement(JS:COMMA)(',')
                 PsiWhiteSpace(' ')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeUnquoted.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/AttributeUnquoted.txt
@@ -14,7 +14,7 @@ SvelteHtmlFile: AttributeUnquoted.svelte
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
               JSBinaryExpression
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('title')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:PLUS)('+')
@@ -41,7 +41,7 @@ SvelteHtmlFile: AttributeUnquoted.svelte
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
               JSBinaryExpression
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('title')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:PLUS)('+')
@@ -73,7 +73,7 @@ SvelteHtmlFile: AttributeUnquoted.svelte
               JSObjectLiteralExpression
                 PsiElement(JS:LBRACE)('{')
                 ES6Property
-                  JSReferenceExpression
+                  SvelteJSReferenceExpression
                     PsiElement(JS:IDENTIFIER)('option')
                 PsiElement(JS:COMMA)(',')
                 PsiWhiteSpace(' ')
@@ -104,14 +104,14 @@ SvelteHtmlFile: AttributeUnquoted.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('title')
             PsiElement(END_MUSTACHE)('}')
           XmlToken:XML_ATTRIBUTE_VALUE_TOKEN('infix')
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('second')
             PsiElement(END_MUSTACHE)('}')
       XmlToken:XML_TAG_END('>')
@@ -134,7 +134,7 @@ SvelteHtmlFile: AttributeUnquoted.svelte
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
               JSBinaryExpression
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('title')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:PLUS)('+')
@@ -167,7 +167,7 @@ SvelteHtmlFile: AttributeUnquoted.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('title')
             PsiElement(END_MUSTACHE)('}')
       XmlToken:XML_TAG_END('>')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockAwaitCatch.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockAwaitCatch.txt
@@ -9,7 +9,7 @@ SvelteHtmlFile: BlockAwaitCatch.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:AWAIT_KEYWORD)('await')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('promise')
           PsiWhiteSpace(' ')
           PsiElement(JS:CATCH_KEYWORD)('catch')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockAwaitThenThenThen.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockAwaitThenThenThen.txt
@@ -9,7 +9,7 @@ SvelteHtmlFile: BlockAwaitThenThenThen.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:AWAIT_KEYWORD)('await')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('then')
           PsiWhiteSpace(' ')
           PsiElement(JS:THEN_KEYWORD)('then')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockEachAmbiguousAs.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockEachAmbiguousAs.txt
@@ -10,10 +10,10 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
           JSBinaryExpression
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiElement(JS:PLUS)('+')
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
           PsiWhiteSpace(' ')
           PsiElement(JS:AS_KEYWORD)('as')
@@ -36,8 +36,8 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
-            JSReferenceExpression
+          SvelteJSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiElement(JS:DOT)('.')
             PsiElement(JS:IDENTIFIER)('as')
@@ -62,8 +62,8 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
-            JSReferenceExpression
+          SvelteJSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:IDENTIFIER)('assets')
             PsiElement(JS:DOT)('.')
             PsiElement(JS:IDENTIFIER)('as')
@@ -88,8 +88,8 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
-            JSReferenceExpression
+          SvelteJSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiElement(JS:DOT)('.')
             PsiElement(JS:IDENTIFIER)('assets')
@@ -114,8 +114,8 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
-            JSReferenceExpression
+          SvelteJSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiElement(JS:DOT)('.')
             PsiWhiteSpace(' ')
@@ -142,7 +142,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
           JSCallExpression
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             JSArgumentList
               PsiElement(JS:LPAR)('(')
@@ -152,7 +152,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
                   PsiElement(JS:IDENTIFIER)('x')
                   PsiElement(JS:COLON)(':')
                   PsiWhiteSpace(' ')
-                  JSReferenceExpression
+                  SvelteJSReferenceExpression
                     PsiElement(JS:AS_KEYWORD)('as')
                 PsiElement(JS:RBRACE)('}')
               PsiElement(JS:RPAR)(')')
@@ -183,7 +183,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
             PsiWhiteSpace(' ')
             PsiElement(JS:PLUS)('+')
             PsiWhiteSpace(' ')
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
           PsiWhiteSpace(' ')
           PsiElement(JS:AS_KEYWORD)('as')
@@ -207,7 +207,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
           JSBinaryExpression
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiWhiteSpace(' ')
             PsiElement(JS:PLUS)('+')
@@ -236,7 +236,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
           JSBinaryExpression
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiWhiteSpace(' ')
             PsiElement(JS:PLUS)('+')
@@ -270,7 +270,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
             PsiWhiteSpace(' ')
             PsiElement(JS:PLUS)('+')
             PsiWhiteSpace(' ')
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
           PsiWhiteSpace(' ')
           PsiElement(JS:AS_KEYWORD)('as')
@@ -294,7 +294,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
           JSBinaryExpression
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiWhiteSpace(' ')
             PsiElement(JS:PLUS)('+')
@@ -324,7 +324,7 @@ SvelteHtmlFile: BlockEachAmbiguousAs.svelte
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
           JSBinaryExpression
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiWhiteSpace(' ')
             PsiElement(JS:PLUS)('+')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockEachAsAsAsAs.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockEachAsAsAsAs.txt
@@ -9,7 +9,7 @@ SvelteHtmlFile: BlockEachAsAsAsAs.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:AS_KEYWORD)('as')
           PsiWhiteSpace(' ')
           PsiElement(JS:AS_KEYWORD)('as')
@@ -19,7 +19,7 @@ SvelteHtmlFile: BlockEachAsAsAsAs.svelte
           PsiWhiteSpace(' ')
           SvelteTagDependentExpression
             PsiElement(JS:LPAR)('(')
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:AS_KEYWORD)('as')
             PsiElement(JS:RPAR)(')')
           PsiElement(JS:RBRACE)('}')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockEachAssets.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockEachAssets.txt
@@ -9,7 +9,7 @@ SvelteHtmlFile: BlockEachAssets.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:EACH_KEYWORD)('each')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('assets')
           PsiWhiteSpace(' ')
           PsiElement(JS:AS_KEYWORD)('as')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockIfElseIf.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockIfElseIf.txt
@@ -9,7 +9,7 @@ SvelteHtmlFile: BlockIfElseIf.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:IF_KEYWORD)('if')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('iffy')
           PsiElement(JS:RBRACE)('}')
         SvelteFragment
@@ -24,7 +24,7 @@ SvelteHtmlFile: BlockIfElseIf.svelte
           PsiWhiteSpace(' ')
           PsiElement(JS:IF_KEYWORD)('if')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('life')
           PsiElement(JS:RBRACE)('}')
         SvelteFragment
@@ -39,7 +39,7 @@ SvelteHtmlFile: BlockIfElseIf.svelte
           PsiWhiteSpace(' ')
           PsiElement(JS:IF_KEYWORD)('if')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('gif')
           PsiElement(JS:RBRACE)('}')
         SvelteFragment

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockNesting.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockNesting.txt
@@ -19,7 +19,7 @@ SvelteHtmlFile: BlockNesting.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:IF_KEYWORD)('if')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('visible')
           PsiElement(JS:RBRACE)('}')
         SvelteFragment
@@ -32,7 +32,7 @@ SvelteHtmlFile: BlockNesting.svelte
                 PsiElement(JS:SHARP)('#')
                 PsiElement(JS:AWAIT_KEYWORD)('await')
                 PsiWhiteSpace(' ')
-                JSReferenceExpression
+                SvelteJSReferenceExpression
                   PsiElement(JS:IDENTIFIER)('promise')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:THEN_KEYWORD)('then')
@@ -52,7 +52,7 @@ SvelteHtmlFile: BlockNesting.svelte
                     PsiElement(JS:AT)('@')
                     PsiElement(JS:HTML_KEYWORD)('html')
                     PsiWhiteSpace(' ')
-                    JSReferenceExpression
+                    SvelteJSReferenceExpression
                       PsiElement(JS:IDENTIFIER)('x')
                     PsiElement(JS:RBRACE)('}')
                   XmlToken:XML_END_TAG_START('</')
@@ -81,7 +81,7 @@ SvelteHtmlFile: BlockNesting.svelte
             PsiElement(JS:AT)('@')
             PsiElement(JS:DEBUG_KEYWORD)('debug')
             PsiWhiteSpace(' ')
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:IDENTIFIER)('name')
             PsiElement(JS:RBRACE)('}')
           XmlText
@@ -116,7 +116,7 @@ SvelteHtmlFile: BlockNesting.svelte
             PsiElement(JS:SHARP)('#')
             PsiElement(JS:EACH_KEYWORD)('each')
             PsiWhiteSpace(' ')
-            JSReferenceExpression
+            SvelteJSReferenceExpression
               PsiElement(JS:IDENTIFIER)('assets')
             PsiWhiteSpace(' ')
             PsiElement(JS:AS_KEYWORD)('as')
@@ -127,7 +127,7 @@ SvelteHtmlFile: BlockNesting.svelte
           SvelteFragment
             SvelteJS: CONTENT_EXPRESSION
               PsiElement(JS:LBRACE)('{')
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('a')
               PsiElement(JS:RBRACE)('}')
         SvelteEndTag(EACH_END)

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockWhitespace.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/BlockWhitespace.txt
@@ -46,7 +46,7 @@ SvelteHtmlFile: BlockWhitespace.svelte
           PsiElement(JS:SHARP)('#')
           PsiElement(JS:IF_KEYWORD)('if')
           PsiWhiteSpace(' ')
-          JSReferenceExpression
+          SvelteJSReferenceExpression
             PsiElement(JS:IDENTIFIER)('a')
           PsiWhiteSpace(' ')
           PsiElement(JS:RBRACE)('}')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/Expression.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/Expression.txt
@@ -39,7 +39,7 @@ SvelteHtmlFile: Expression.svelte
       PsiElement(JS:AT)('@')
       PsiElement(JS:DEBUG_KEYWORD)('debug')
       PsiWhiteSpace(' ')
-      JSReferenceExpression
+      SvelteJSReferenceExpression
         PsiElement(JS:IDENTIFIER)('x')
       PsiElement(JS:RBRACE)('}')
     PsiWhiteSpace('\n')
@@ -49,7 +49,7 @@ SvelteHtmlFile: Expression.svelte
       PsiElement(JS:AT)('@')
       PsiElement(JS:DEBUG_KEYWORD)('debug')
       PsiWhiteSpace(' ')
-      JSReferenceExpression
+      SvelteJSReferenceExpression
         PsiElement(JS:IDENTIFIER)('x')
       PsiWhiteSpace(' ')
       PsiElement(JS:RBRACE)('}')
@@ -62,7 +62,7 @@ SvelteHtmlFile: Expression.svelte
       PsiWhiteSpace(' ')
       PsiElement(JS:DEBUG_KEYWORD)('debug')
       PsiWhiteSpace(' ')
-      JSReferenceExpression
+      SvelteJSReferenceExpression
         PsiElement(JS:IDENTIFIER)('x')
       PsiElement(JS:RBRACE)('}')
     PsiWhiteSpace('\n')
@@ -72,6 +72,6 @@ SvelteHtmlFile: Expression.svelte
       PsiErrorElement:expected html or debug
         PsiElement(JS:IDENTIFIER)('unknown')
       PsiWhiteSpace(' ')
-      JSReferenceExpression
+      SvelteJSReferenceExpression
         PsiElement(JS:IDENTIFIER)('x')
       PsiElement(JS:RBRACE)('}')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/Let.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/Let.txt
@@ -13,7 +13,7 @@ SvelteHtmlFile: Let.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('local')
             PsiElement(END_MUSTACHE)('}')
       PsiWhiteSpace(' ')
@@ -30,7 +30,7 @@ SvelteHtmlFile: Let.svelte
       XmlToken:XML_TAG_END('>')
       SvelteJS: CONTENT_EXPRESSION
         PsiElement(JS:LBRACE)('{')
-        JSReferenceExpression
+        SvelteJSReferenceExpression
           PsiElement(JS:IDENTIFIER)('local')
         PsiElement(JS:RBRACE)('}')
       XmlToken:XML_END_TAG_START('</')
@@ -48,7 +48,7 @@ SvelteHtmlFile: Let.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('local')
             PsiElement(END_MUSTACHE)('}')
       PsiWhiteSpace(' ')
@@ -57,7 +57,7 @@ SvelteHtmlFile: Let.svelte
       XmlToken:XML_TAG_END('>')
       SvelteJS: CONTENT_EXPRESSION
         PsiElement(JS:LBRACE)('{')
-        JSReferenceExpression
+        SvelteJSReferenceExpression
           PsiElement(JS:IDENTIFIER)('local')
         PsiElement(JS:RBRACE)('}')
       XmlToken:XML_END_TAG_START('</')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/QuoteBalanceUnclosedStringLiteral.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/QuoteBalanceUnclosedStringLiteral.txt
@@ -22,7 +22,7 @@ SvelteHtmlFile: QuoteBalanceUnclosedStringLiteral.svelte
             JSExpressionStatement
               JSAssignmentExpression
                 JSDefinitionExpression
-                  JSReferenceExpression
+                  SvelteJSReferenceExpression
                     PsiElement(JS:IDENTIFIER)('text')
                 PsiWhiteSpace(' ')
                 PsiElement(JS:EQ)('=')

--- a/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/StyleAttributeWithExpressionEnd.txt
+++ b/src/test/resources/dev/blachut/svelte/lang/parsing/html/parser/StyleAttributeWithExpressionEnd.txt
@@ -46,7 +46,7 @@ SvelteHtmlFile: StyleAttributeWithExpressionEnd.svelte
           SveltePsiElement
             PsiElement(START_MUSTACHE)('{')
             SvelteJS: ATTRIBUTE_EXPRESSION
-              JSReferenceExpression
+              SvelteJSReferenceExpression
                 PsiElement(JS:IDENTIFIER)('svelteColor')
             PsiElement(END_MUSTACHE)('}')
           XmlToken:XML_ATTRIBUTE_VALUE_END_DELIMITER('"')


### PR DESCRIPTION
This PR fixes Find Usages dialog, making store references two-way so to speak.

![image](https://user-images.githubusercontent.com/615013/90342099-d585de80-e005-11ea-9d08-705eb8773b80.png)

Next steps: (minor ones first because they are shorter)
* Figure out how to stop selecting `$` when double clicking on identifier. (keyword: word boundary)
* Mark variables named starting with `$` as errors
* Validate (and postprocess?) renames

TODO
- [ ] Provide normal completions after typing `$`
- [x] Include store type unwrapping

```ts
export interface Readable<T> {
	/**
	 * Subscribe on value changes.
	 * @param run subscription callback
	 * @param invalidate cleanup callback
	 */
	subscribe(run: Subscriber<T>, invalidate?: Invalidator<T>): Unsubscriber;
}

type Subscriber<T> = (value: T) => void;
```
https://github.com/sveltejs/svelte/blob/master/src/runtime/store/index.ts

~AFAIK the way to go about types is to attach `JSImplicitElement` to `JSVariable`, and change resolving so the reference resolves to implicit element instead of real one. I know how to do that.~
More challenging thing for me is to configure `getJSType` to return correct type, `T` in previous snippet.

@anstarovoyt feedback or some examples would be great