### PR TITLE
Remove deprecated methods from SvelteJSLanguage

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSBlockLazyElementType.kt
+++ b/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSBlockLazyElementType.kt
@@ -3,11 +3,11 @@ package dev.blachut.svelte.lang.psi
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiBuilderFactory
+import com.intellij.lang.javascript.JSLanguageUtil
 import com.intellij.lang.javascript.parsing.JavaScriptParser
 import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.ILazyParseableElementType
 import dev.blachut.svelte.lang.SvelteJSLanguage
-import dev.blachut.svelte.lang.parsing.js.SvelteJSParser
 
 // TODO Merge SvelteJSBlockLazyElementType & SvelteJSLazyElementType
 abstract class SvelteJSBlockLazyElementType(debugName: String) :
@@ -23,7 +23,7 @@ abstract class SvelteJSBlockLazyElementType(debugName: String) :
     override fun doParseContents(chameleon: ASTNode, psi: PsiElement): ASTNode {
         val project = psi.project
         val builder = PsiBuilderFactory.getInstance().createBuilder(project, chameleon, null, language, chameleon.chars)
-        val parser = SvelteJSParser(builder)
+        val parser = JSLanguageUtil.createJSParser(language, builder)
 
         val rootMarker = builder.mark()
 

--- a/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSLazyElementType.kt
+++ b/src/main/java/dev/blachut/svelte/lang/psi/SvelteJSLazyElementType.kt
@@ -3,11 +3,11 @@ package dev.blachut.svelte.lang.psi
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiBuilderFactory
+import com.intellij.lang.javascript.JSLanguageUtil
 import com.intellij.lang.javascript.parsing.JavaScriptParser
 import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.ILazyParseableElementType
 import dev.blachut.svelte.lang.SvelteJSLanguage
-import dev.blachut.svelte.lang.parsing.js.SvelteJSParser
 
 // TODO Merge SvelteJSBlockLazyElementType & SvelteJSLazyElementType
 abstract class SvelteJSLazyElementType(debugName: String) : ILazyParseableElementType(debugName, SvelteJSLanguage.INSTANCE) {
@@ -22,7 +22,7 @@ abstract class SvelteJSLazyElementType(debugName: String) : ILazyParseableElemen
     override fun doParseContents(chameleon: ASTNode, psi: PsiElement): ASTNode {
         val project = psi.project
         val builder = PsiBuilderFactory.getInstance().createBuilder(project, chameleon, null, language, chameleon.chars)
-        val parser = SvelteJSParser(builder)
+        val parser = JSLanguageUtil.createJSParser(language, builder)
 
         val rootMarker = builder.mark()
 


### PR DESCRIPTION
Merge when dropping 2020.1, before 2020.3