### PR TITLE
enable eslint support for svelte files, fixes #24

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/linters/EslintInitStartupActivity.kt
+++ b/src/main/java/dev/blachut/svelte/lang/linters/EslintInitStartupActivity.kt
@@ -1,0 +1,28 @@
+package dev.blachut.svelte.lang.linters
+
+import com.intellij.ide.util.RunOnceUtil
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.util.registry.Registry
+import java.util.*
+
+class EslintInitStartupActivity : StartupActivity {
+
+    override fun runActivity(project: Project) {
+        val key = "eslint.additional.file.extensions"
+
+        RunOnceUtil.runOnceForApp("svelte.init.key") {
+            try {
+                val stringValue = Registry.stringValue(key)
+                if (!stringValue.contains("svelte")) {
+                    val newValue = if (stringValue.isEmpty()) "svelte" else "$stringValue,svelte"
+                    val value = Registry.get(key)
+                    value.setValue(newValue)
+                }
+            } catch (e: MissingResourceException) {
+                Logger.getInstance(EslintInitStartupActivity::class.java).warn("Cannot find the key: $key")
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,6 +60,7 @@
         <css.embeddedCssProvider implementation="dev.blachut.svelte.lang.css.SvelteEmbeddedCssProvider"/>
         <css.inclusionContext implementation="dev.blachut.svelte.lang.css.SvelteCssInclusionContext"/>
         <highlightErrorFilter implementation="dev.blachut.svelte.lang.css.SvelteCssExpressionErrorFilter"/>
+        <postStartupActivity implementation="dev.blachut.svelte.lang.linters.EslintInitStartupActivity"/>
     </extensions>
     <extensions defaultExtensionNs="JavaScript">
         <dialectSpecificHandlersFactory language="SvelteJS"


### PR DESCRIPTION
I thought about better strategies like auto-detection of "svelte3" plugin and enabling only for it, but looks like the simplest solution is the best here. 