### PR TITLE
Fix some unused imports cases

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReferencesSearch.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReferencesSearch.kt
@@ -1,78 +1,38 @@
 package dev.blachut.svelte.lang.codeInsight
 
 
-import com.intellij.lang.ecmascript6.psi.ES6ExportSpecifierAlias
-import com.intellij.lang.ecmascript6.psi.ES6ImportExportSpecifierAlias
-import com.intellij.lang.ecmascript6.psi.ES6ImportSpecifierAlias
-import com.intellij.lang.ecmascript6.psi.ES6ImportedBinding
 import com.intellij.lang.javascript.psi.JSElement
+import com.intellij.lang.javascript.psi.JSEmbeddedContent
 import com.intellij.openapi.application.QueryExecutorBase
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceService
 import com.intellij.psi.search.LocalSearchScope
-import com.intellij.psi.search.RequestResultProcessor
 import com.intellij.psi.search.UsageSearchContext
 import com.intellij.psi.search.searches.ReferencesSearch
-import com.intellij.psi.xml.XmlTag
 import com.intellij.util.Processor
-import dev.blachut.svelte.lang.isSvelteContext
+import dev.blachut.svelte.lang.psi.SvelteHtmlFile
 
 class SvelteReferencesSearch : QueryExecutorBase<PsiReference, ReferencesSearch.SearchParameters>(true) {
     override fun processQuery(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<in PsiReference>) {
         val element = queryParameters.elementToSearch
-        val containingFile = element.containingFile
         val componentName = (element as? JSElement)?.name ?: return
 
-        if (isSvelteContext(containingFile)) {
-            if (element is ES6ImportedBinding) {
-                queryParameters.optimizer.searchWord(
-                    componentName,
-                    LocalSearchScope(containingFile),
-                    UsageSearchContext.IN_CODE,
-                    true,
-                    element
-                )
-            }
-            if (element is ES6ImportSpecifierAlias) {
-                queryParameters.optimizer.searchWord(
-                    componentName,
-                    LocalSearchScope(containingFile),
-                    UsageSearchContext.IN_CODE,
-                    true,
-                    element,
-                    MyProcessor(element)
-                )
-            }
-        }
-        if (element is ES6ExportSpecifierAlias && queryParameters.effectiveSearchScope is LocalSearchScope) {
-            val scope = (queryParameters.effectiveSearchScope as LocalSearchScope).scope.firstOrNull() ?: return
-            if (!isSvelteContext(scope.containingFile)) return
-
-            queryParameters.optimizer.searchWord(
-                componentName,
-                LocalSearchScope(scope.containingFile),
-                UsageSearchContext.IN_CODE,
-                true,
-                element,
-                MyProcessor(element)
-            )
-        }
-    }
-
-    private class MyProcessor(private val target: ES6ImportExportSpecifierAlias) : RequestResultProcessor(target) {
-        override fun processTextOccurrence(element: PsiElement, offsetInElement: Int, consumer: Processor<in PsiReference>): Boolean {
-            if (!target.isValid) {
-                return false
-            }
-
-            if (element is XmlTag) {
-                if (element.name == target.name) {
-                    val references = PsiReferenceService.getService().getReferences(element, PsiReferenceService.Hints(target, offsetInElement))
-                    references.forEach { consumer.process(it) }
+        val searchScope = queryParameters.effectiveSearchScope
+        if (searchScope is LocalSearchScope) {
+            val scopes = searchScope.scope
+            for (scope in scopes) {
+                if (scope is JSEmbeddedContent) {
+                    val containingFile = scope.containingFile
+                    if (containingFile is SvelteHtmlFile) {
+                        queryParameters.optimizer.searchWord(
+                            componentName,
+                            LocalSearchScope(containingFile),
+                            UsageSearchContext.IN_CODE,
+                            true,
+                            element
+                        )
+                    }
                 }
             }
-            return true
         }
     }
 }


### PR DESCRIPTION
This is a simplification of the SvelteReferencesSearch class, it solves more unused imports cases, maybe all
Basically, it enlarges the search scope from the script to the entire file

Current

![image](https://user-images.githubusercontent.com/793712/91662358-e6405500-ead9-11ea-9c2a-00508d6d17ee.png)

Improvement

![2020-08-30_15-42](https://user-images.githubusercontent.com/793712/91662292-5ac6c400-ead9-11ea-9a04-096a39e2dbee.png)

This can probably be done using `<resolveScopeEnlarger/>` but I'm not sure