### PR TITLE
Fix reactive declarations in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-### 
+- Fix unresolved reactive declarations in TypeScript
+
 ## [0.15.0]
 - Support TypeScript
 - Support #key block

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReactiveDeclarationsUtil.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteReactiveDeclarationsUtil.kt
@@ -1,10 +1,13 @@
 package dev.blachut.svelte.lang.codeInsight
 
+import com.intellij.lang.javascript.ecmascript6.TypeScriptResolveProcessor
 import com.intellij.lang.javascript.psi.JSDefinitionExpression
 import com.intellij.lang.javascript.psi.JSLabeledStatement
+import com.intellij.lang.javascript.psi.resolve.ResolveResultSink
 import com.intellij.lang.javascript.psi.resolve.ResultSink
 import com.intellij.lang.javascript.psi.resolve.SinkResolveProcessor
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.parentOfType
 
@@ -13,6 +16,22 @@ object SvelteReactiveDeclarationsUtil {
 
     class SvelteSinkResolveProcessor<T : ResultSink>(name: String?, place: PsiElement, sink: T) :
         SinkResolveProcessor<T>(name, place, sink) {
+        override fun executeAcceptedElement(element: PsiElement, state: ResolveState): Boolean {
+            val shouldContinue = super.executeAcceptedElement(element, state)
+
+            if (shouldContinue && element is JSDefinitionExpression) {
+                val labeledStatement = element.parentOfType<JSLabeledStatement>()
+                if (labeledStatement != null && labeledStatement.label == REACTIVE_LABEL) {
+                    addPossibleCandidateResult(element, null)
+                }
+            }
+
+            return true
+        }
+    }
+
+    class SvelteTypeScriptResolveProcessor<T : ResultSink>(sink: T, containingFile: PsiFile, place: PsiElement) :
+        TypeScriptResolveProcessor<ResolveResultSink>(sink, containingFile, place) {
         override fun executeAcceptedElement(element: PsiElement, state: ResolveState): Boolean {
             val shouldContinue = super.executeAcceptedElement(element, state)
 

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteTypeScriptReferenceExpressionResolver.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteTypeScriptReferenceExpressionResolver.kt
@@ -2,10 +2,12 @@
 package dev.blachut.svelte.lang.codeInsight
 
 import com.intellij.lang.javascript.ecmascript6.TypeScriptReferenceExpressionResolver
+import com.intellij.lang.javascript.psi.JSLabeledStatement
 import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
 import com.intellij.lang.javascript.psi.resolve.ResolveResultSink
 import com.intellij.lang.javascript.psi.resolve.SinkResolveProcessor
 import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.parentOfType
 import dev.blachut.svelte.lang.codeInsight.SvelteJSReferenceExpressionResolver.Companion.resolveImplicits
 
 class SvelteTypeScriptReferenceExpressionResolver(
@@ -16,10 +18,29 @@ class SvelteTypeScriptReferenceExpressionResolver(
         val resolveImplicits = resolveImplicits(expression)
         if (resolveImplicits.isNotEmpty()) return resolveImplicits
 
-        return super.resolve(expression, incompleteCode)
+        val resolved = super.resolve(expression, incompleteCode)
+
+        if (resolved.isEmpty() && expression.qualifier == null && myReferencedName != null) {
+            val sink = ResolveResultSink(myRef, myReferencedName, false, incompleteCode)
+            val localProcessor = createLocalResolveProcessor(sink)
+            JSReferenceExpressionImpl.doProcessLocalDeclarations(
+                myRef,
+                myQualifier,
+                localProcessor,
+                false,
+                false,
+                null
+            )
+            val jsElement = localProcessor.result
+            val labeledStatement = jsElement.parentOfType<JSLabeledStatement>()
+            if (labeledStatement != null && labeledStatement.label == SvelteReactiveDeclarationsUtil.REACTIVE_LABEL) {
+                return localProcessor.resultsAsResolveResults
+            }
+        }
+        return resolved
     }
 
     override fun createLocalResolveProcessor(sink: ResolveResultSink): SinkResolveProcessor<ResolveResultSink> {
-        return SvelteReactiveDeclarationsUtil.SvelteSinkResolveProcessor(myReferencedName, myRef, sink)
+        return SvelteReactiveDeclarationsUtil.SvelteTypeScriptResolveProcessor(sink, myContainingFile, myRef)
     }
 }


### PR DESCRIPTION
Fixes #167. I only did quick checkup, need to do more regression testing before merging, I don't have more time now unfortunately.

@anstarovoyt how bad do you think this solution is? I though maybe you could change actual `TypeScriptReferenceExpressionResolver` a bit in WS 2020.3 so this `TypeScriptReferenceExpressionResolver2` could be deleted later.