### PR TITLE
Support WebStorm 2022.2 EAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ val generateSvelteLexer = task<GenerateLexerTask>("generateSvelteLexer") {
 }
 
 tasks {
-    val javaVersion = "17"
+    val javaVersion = "11"
 
     // Set the JVM compatibility versions
     withType<JavaCompile> {
@@ -91,7 +91,7 @@ tasks {
     withType<KotlinCompile> {
         dependsOn(generateSvelteLexer)
         kotlinOptions.jvmTarget = javaVersion
-        kotlinOptions.languageVersion = "1.6"
+        kotlinOptions.languageVersion = "1.5"
         kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=compatibility")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
-    id("org.jetbrains.intellij") version "1.4.0"
+    id("org.jetbrains.intellij") version "1.6.0"
     id("org.jetbrains.changelog") version "1.3.1"
     id("org.jetbrains.grammarkit") version "2021.2.1"
 }
@@ -20,7 +20,8 @@ version = properties("pluginVersion")
 val sassPlugin = when {
     properties("platformVersion").startsWith("212") -> "org.jetbrains.plugins.sass:212.4746.57"
     properties("platformVersion").startsWith("213") -> "org.jetbrains.plugins.sass:213.5744.269"
-    properties("platformVersion").startsWith("221") -> "org.jetbrains.plugins.sass:221.5080.20"
+    properties("platformVersion").startsWith("221") -> "org.jetbrains.plugins.sass:221.5591.52"
+    properties("platformVersion").startsWith("222") -> "org.jetbrains.plugins.sass:222.2270.35"
     else -> throw GradleException("Missing Sass plugin version for platformVersion = ${properties("platformVersion")}")
 }
 
@@ -29,6 +30,8 @@ val psiViewerPlugin = when {
     properties("platformVersion").startsWith("212") -> "PsiViewer:212-SNAPSHOT"
     properties("platformVersion").startsWith("213") -> "PsiViewer:213-SNAPSHOT"
     properties("platformVersion").startsWith("221") -> "PsiViewer:221-SNAPSHOT"
+    properties("platformVersion").startsWith("222") -> "PsiViewer:222-SNAPSHOT"
+
     else -> null
 }
 
@@ -76,7 +79,7 @@ val generateSvelteLexer = task<GenerateLexerTask>("generateSvelteLexer") {
 }
 
 tasks {
-    val javaVersion = "11"
+    val javaVersion = "17"
 
     // Set the JVM compatibility versions
     withType<JavaCompile> {
@@ -88,7 +91,7 @@ tasks {
     withType<KotlinCompile> {
         dependsOn(generateSvelteLexer)
         kotlinOptions.jvmTarget = javaVersion
-        kotlinOptions.languageVersion = "1.5"
+        kotlinOptions.languageVersion = "1.6"
         kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=compatibility")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,17 +2,17 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=dev.blachut.svelte.lang
 pluginName=svelte-intellij
-pluginVersion=0.22.0
+pluginVersion=0.23.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.5080
-pluginUntilBuild=221.*
+pluginUntilBuild=222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=
 # https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IU
-platformVersion=221-EAP-SNAPSHOT
+platformVersion=222-EAP-SNAPSHOT
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=dev.blachut.svelte.lang
 pluginName=svelte-intellij
-pluginVersion=0.23.0
+pluginVersion=0.22.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.5080

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteComponentCandidatesProvider.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteComponentCandidatesProvider.kt
@@ -33,7 +33,7 @@ class SvelteComponentCandidatesProvider(placeInfo: JSImportPlaceInfo) : JSImport
         return true
     }
 
-    override fun getNames(keyFilter: Predicate<in String>): MutableSet<String> {
+    override fun getNames(keyFilter: Predicate<in String>): Set<String> {
         return FilenameIndex.getAllFilesByExt(project, "svelte").stream()
             .map(::getComponentName)
             .filter(keyFilter)

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteComponentCandidatesProvider.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteComponentCandidatesProvider.kt
@@ -33,7 +33,7 @@ class SvelteComponentCandidatesProvider(placeInfo: JSImportPlaceInfo) : JSImport
         return true
     }
 
-    override fun getNames(keyFilter: Predicate<String>): Set<String> {
+    override fun getNames(keyFilter: Predicate<in String>): MutableSet<String> {
         return FilenameIndex.getAllFilesByExt(project, "svelte").stream()
             .map(::getComponentName)
             .filter(keyFilter)

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteKitModuleReferenceContributor.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteKitModuleReferenceContributor.kt
@@ -65,10 +65,10 @@ class SvelteKitModuleReferenceContributor : JSResolvableModuleReferenceContribut
 
     // based on TypeScriptUtil.createFilterByNodeModuleScope
     private fun createFilterByNodeModuleScope(scope: GlobalSearchScope, context: PsiElement): GlobalSearchScope {
-        var context = context
-        if (context is PsiFile) context = context.originalFile
-        val contextFile = PsiUtilCore.getVirtualFile(context)
-        val index = ProjectFileIndex.getInstance(context.project)
+        var mutableContext = context
+        if (mutableContext is PsiFile) mutableContext = mutableContext.originalFile
+        val contextFile = PsiUtilCore.getVirtualFile(mutableContext)
+        val index = ProjectFileIndex.getInstance(mutableContext.project)
         val resultScope = if (contextFile == null) scope
         else object : DelegatingGlobalSearchScope(scope) {
             override fun contains(file: VirtualFile): Boolean {

--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteKitModuleReferenceContributor.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteKitModuleReferenceContributor.kt
@@ -65,10 +65,10 @@ class SvelteKitModuleReferenceContributor : JSResolvableModuleReferenceContribut
 
     // based on TypeScriptUtil.createFilterByNodeModuleScope
     private fun createFilterByNodeModuleScope(scope: GlobalSearchScope, context: PsiElement): GlobalSearchScope {
-        var mutableContext = context
-        if (mutableContext is PsiFile) mutableContext = mutableContext.originalFile
-        val contextFile = PsiUtilCore.getVirtualFile(mutableContext)
-        val index = ProjectFileIndex.getInstance(mutableContext.project)
+        var context = context
+        if (context is PsiFile) context = context.originalFile
+        val contextFile = PsiUtilCore.getVirtualFile(context)
+        val index = ProjectFileIndex.getInstance(context.project)
         val resultScope = if (contextFile == null) scope
         else object : DelegatingGlobalSearchScope(scope) {
             override fun contains(file: VirtualFile): Boolean {

--- a/src/main/java/dev/blachut/svelte/lang/completion/SvelteAttributeValueCompletionProvider.kt
+++ b/src/main/java/dev/blachut/svelte/lang/completion/SvelteAttributeValueCompletionProvider.kt
@@ -53,7 +53,7 @@ class SvelteAttributeValueCompletionProvider : CompletionProvider<CompletionPara
         result.add("css")
         CSSLanguage.INSTANCE.dialects.forEach {
             if (it.displayName != "JQuery-CSS") {
-                result.add(it.displayName.toLowerCase(Locale.US))
+                result.add(it.displayName.lowercase(Locale.US))
             }
         }
         return result.toSet()


### PR DESCRIPTION
Currently JetBrains is running a closed beta with the new UI design. I would like to have the latest EAP to support the plugin. I do not know if it will work, reading from the docs this should do the trick from the side of IDEA telling it is supported.